### PR TITLE
Update pending_retraction.txt.mako

### DIFF
--- a/website/templates/emails/pending_retraction.txt.mako
+++ b/website/templates/emails/pending_retraction.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-I just wanted to let you know, an administrator has initiated a retraction for the following registration: ${registration_link}
+I just wanted to let you know, another administrator has initiated a retraction for your registration: ${registration_link}
 
 To approve this action click the following link: ${approval_link}
 


### PR DESCRIPTION
Made a slight revision.  Can we call which administrator initiated the retraction and replace "another administrator" with that insertion?
