### PR TITLE
Update pending_embargo.txt.mako

### DIFF
--- a/website/templates/emails/pending_embargo.txt.mako
+++ b/website/templates/emails/pending_embargo.txt.mako
@@ -1,6 +1,6 @@
 Hello ${user.fullname},
 
-I just wanted to let you know, an administrator has requested an embargoed registration for a project you adminstor.
+I just wanted to let you know, another administrator has requested an embargoed registration for a project you adminstor.
 
 The proposed registration can be reviewed here: ${registration_link}.
 


### PR DESCRIPTION
Made the same very minor edit as done for retractions.  The same change there would be good here - replacing "another administrator" with the name of the administrator.

Also, the same text could be used with "embargoed" removed for an immediate registration.  OR, this text could be edited so that it works for both embargoed and non-embargoed registrations.  I think that would just be removing "embargoed" from the opening sentence and then having the embargo end date be 48 hours after registration for "immediate" releases.
